### PR TITLE
Improve template validation and sanitization

### DIFF
--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+function mergeCoverage(dir) {
+  const map = new Map();
+  for (const file of fs.readdirSync(dir)) {
+    const json = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+    for (const result of json.result) {
+      if (!result.url.startsWith('file://')) continue;
+      const filepath = result.url.replace('file://', '');
+      const cwd = process.cwd();
+      if (
+        !filepath.startsWith(path.join(cwd, 'utils')) &&
+        !filepath.startsWith(path.join(cwd, 'tests'))
+      ) {
+        continue;
+      }
+    const info = map.get(filepath) || [];
+      for (const fn of result.functions) {
+        for (const range of fn.ranges) info.push(range);
+      }
+      map.set(filepath, info);
+    }
+  }
+  return map;
+}
+
+function rangeCoverage(ranges) {
+  const uniq = new Map();
+  for (const r of ranges) {
+    const key = r.startOffset + ':' + r.endOffset;
+    const existing = uniq.get(key) || { start: r.startOffset, end: r.endOffset, count: 0 };
+    if (r.count > 0) existing.count = r.count;
+    uniq.set(key, existing);
+  }
+  let total = 0, covered = 0;
+  for (const r of uniq.values()) {
+    total++;
+    if (r.count > 0) covered++;
+  }
+  return { total, covered, pct: (covered / total) * 100 };
+}
+
+const map = mergeCoverage('.cov');
+let totalCovered = 0, total = 0;
+for (const [file, ranges] of map.entries()) {
+  const { covered, total: t, pct } = rangeCoverage(ranges);
+  totalCovered += covered;
+  total += t;
+  console.log(`${file} -> ${pct.toFixed(2)}% (${covered}/${t})`);
+}
+console.log(`TOTAL -> ${(totalCovered / total * 100).toFixed(2)}% (${totalCovered}/${total})`);

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -7,4 +7,11 @@ describe("sanitizeHtml", () => {
     const clean = sanitizeHtml(dirty);
     expect(clean).toBe("<div>Hi</div>");
   });
+
+  it("strips javascript and data URLs", () => {
+    const dirty =
+      '<a href="javascript:alert(1)" src="data:text/html;base64,AAAA">link</a>';
+    const clean = sanitizeHtml(dirty);
+    expect(clean).toBe("<a>link</a>");
+  });
 });

--- a/tests/utils/templateIntegration.test.ts
+++ b/tests/utils/templateIntegration.test.ts
@@ -12,4 +12,11 @@ describe("integrateTemplates", () => {
     // invalid input passed intentionally
     expect(() => integrateTemplates(null as any)).toThrow(TypeError);
   });
+
+  it("strips extraneous fields and returns new objects", () => {
+    const tpl: any = { title: "A", body: "b", evil: "x" };
+    const [result] = integrateTemplates([tpl]);
+    expect(result).toEqual({ title: "A", body: "b" });
+    expect(result).not.toBe(tpl);
+  });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -9,6 +9,9 @@ describe("validateDocument", () => {
   it("returns false otherwise", () => {
     expect(validateDocument({})).toBe(false);
     expect(validateDocument(null)).toBe(false);
+    const arr: any = [];
+    arr.content = "x";
+    expect(validateDocument(arr)).toBe(false);
   });
 });
 
@@ -20,5 +23,9 @@ describe("validateTemplate", () => {
   it("returns false otherwise", () => {
     expect(validateTemplate({ title: "t" })).toBe(false);
     expect(validateTemplate(null)).toBe(false);
+    const arr: any = [];
+    arr.title = "t";
+    arr.body = "b";
+    expect(validateTemplate(arr)).toBe(false);
   });
 });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -10,7 +10,15 @@ export function sanitizeHtml(html: string): string {
   // Remove event handler attributes like onclick
   doc.querySelectorAll("*").forEach((el) => {
     for (const attr of Array.from(el.attributes)) {
-      if (attr.name.startsWith("on")) {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith("on")) {
+        el.removeAttribute(attr.name);
+        continue;
+      }
+      if (
+        (name === "href" || name === "src") &&
+        /^(javascript|data):/i.test(attr.value.trim())
+      ) {
         el.removeAttribute(attr.name);
       }
     }

--- a/utils/templateIntegration.ts
+++ b/utils/templateIntegration.ts
@@ -17,6 +17,11 @@ export function integrateTemplates(templates: unknown[]): Template[] {
     throw new TypeError("templates must be an array");
   }
 
-  return templates.filter(validateTemplate) as Template[];
+  return templates
+    .filter(validateTemplate)
+    .map((t) => {
+      const rec = t as Record<string, unknown>;
+      return { title: String(rec.title), body: String(rec.body) };
+    });
 }
 

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -4,7 +4,7 @@
  * @returns `true` if the document has a `content` string field, `false` otherwise.
  */
 export function validateDocument(doc: unknown): boolean {
-  if (typeof doc !== "object" || doc === null) {
+  if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
     return false;
   }
   return typeof (doc as Record<string, unknown>).content === "string";
@@ -16,7 +16,7 @@ export function validateDocument(doc: unknown): boolean {
  * @returns `true` if both fields exist and are strings.
  */
 export function validateTemplate(tpl: unknown): boolean {
-  if (typeof tpl !== "object" || tpl === null) {
+  if (typeof tpl !== "object" || tpl === null || Array.isArray(tpl)) {
     return false;
   }
   const rec = tpl as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- harden HTML sanitizer against `javascript:` and `data:` URLs
- reject array values in document and template validators
- normalize templates by cloning only title/body fields

## Testing
- `npm test`
- `NODE_V8_COVERAGE=.cov npm test && node scripts/coverage-summary.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68abb63734fc8332b809ec95f9f9403b