### PR TITLE
Enable Codex page test and fix page export

### DIFF
--- a/pages/codex.tsx
+++ b/pages/codex.tsx
@@ -1,5 +1,4 @@
-import dynamic from "next/dynamic";
-import { useState } from "react";
+import React, { useState } from "react";
 
 /**
  * Editor.js demo page.
@@ -102,4 +101,4 @@ function CodexPage() {
   );
 }
 
-export default dynamic(() => Promise.resolve(CodexPage), { ssr: false });
+export default CodexPage;

--- a/tests/pages/codex.test.tsx
+++ b/tests/pages/codex.test.tsx
@@ -3,10 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import CodexPage from "../../pages/codex";
 
-describe.skip("CodexPage", () => {
+describe("CodexPage", () => {
   it("renders heading", () => {
     render(<CodexPage />);
-    expect(screen.getByText("Editor.js")).toBeInTheDocument();
-    expect(screen.getByLabelText("Add Comment")).toBeInTheDocument();
+    expect(screen.getByText("Editor.js")).toBeTruthy();
+    expect(screen.getByLabelText("Add Comment")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Run Codex page test instead of skipping
- Export Codex page directly and import React

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad7a5e091883328d997d04ce77c16a