### PR TITLE
test(slate): enable slate page test

### DIFF
--- a/pages/slate.tsx
+++ b/pages/slate.tsx
@@ -1,5 +1,4 @@
-import dynamic from "next/dynamic";
-import { useState } from "react";
+import React, { useState } from "react";
 
 /**
  * Slate demo page.
@@ -102,4 +101,4 @@ function SlatePage() {
   );
 }
 
-export default dynamic(() => Promise.resolve(SlatePage), { ssr: false });
+export default SlatePage;

--- a/tests/pages/slate.test.tsx
+++ b/tests/pages/slate.test.tsx
@@ -3,10 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import SlatePage from "../../pages/slate";
 
-describe.skip("SlatePage", () => {
+describe("SlatePage", () => {
   it("renders heading", () => {
     render(<SlatePage />);
-    expect(screen.getByText("Slate")).toBeInTheDocument();
-    expect(screen.getByLabelText("Add Comment")).toBeInTheDocument();
+    expect(screen.getByText("Slate")).toBeTruthy();
+    expect(screen.getByLabelText("Add Comment")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- enable Slate page unit test
- export Slate page directly to render during tests

## Testing
- `npm test`
- `npm run lint`
- `npx prettier --check .` *(fails: code style issues in 34 files)*
- `npm run typecheck` *(fails: multiple TypeScript errors)*
- `npm audit --prod --audit-level=high` *(fails: 403 Forbidden)*
- `npx vitest run -m property` *(fails: unknown option -m)*
- `npx playwright install --with-deps --dry-run`
- `npx playwright test --reporter=line` *(fails: browsers not installed)*
- `npx stryker run --coverageAnalysis=perTest --threshold-break 60` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7b56b90c8332a99ab18f9ae1222b