### PR TITLE
Enable TipTap page unit test

### DIFF
--- a/tests/pages/tiptap.test.tsx
+++ b/tests/pages/tiptap.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import TiptapPage from "../../pages/tiptap";
 
-describe.skip("TiptapPage", () => {
+describe("TiptapPage", () => {
   it("renders heading", () => {
     render(<TiptapPage />);
-    expect(screen.getByText("TipTap Editor")).toBeInTheDocument();
+    expect(screen.getByText("TipTap Editor")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Unskip TipTap page test and assert heading renders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7fda681083329e169866a8cf3fbb