### PR TITLE
fix: add DOM fallbacks and enforce structure rules

### DIFF
--- a/extensions/slash-command.ts
+++ b/extensions/slash-command.ts
@@ -32,7 +32,7 @@ export default Extension.create<SlashCommandOptions>({
             .chain()
             .focus()
             .deleteRange(range)
-            .insertContent(props.label)
+            .insertContent(props.label ?? "")
             .run();
         },
         items: () => [],

--- a/extensions/tiptapStructure.ts
+++ b/extensions/tiptapStructure.ts
@@ -3,6 +3,7 @@
  */
 import { Extension } from "@tiptap/core";
 import { Plugin } from "prosemirror-state";
+import { JSDOM } from "jsdom";
 
 /**
  * Extension skeleton enforcing heading structure rules.
@@ -49,11 +50,14 @@ export function tiptapStructure() {
  * Basic validator used in tests to verify no consecutive headings.
  */
 export function isValidStructure(html: string): boolean {
-  const doc = new DOMParser().parseFromString(html, "text/html");
+  const Parser =
+    typeof DOMParser !== "undefined" ? DOMParser : new JSDOM("").window.DOMParser;
+  const doc: Document = new Parser().parseFromString(html, "text/html");
   let prevHeading = false;
-  for (const el of Array.from(doc.body.children)) {
+  for (const el of Array.from(doc.body.children) as Element[]) {
     const isHeading = /^H[1-6]$/.test(el.tagName);
     if (isHeading && prevHeading) return false;
+    if (prevHeading && !["P", "UL", "OL"].includes(el.tagName)) return false;
     prevHeading = isHeading;
   }
   return true;

--- a/tests/extensions/slash-command.test.ts
+++ b/tests/extensions/slash-command.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
-import SlashCommand from "../../extensions/slash-command";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import SlashCommand from "../../extensions/slash-command.js";
 
 describe("slash-command extension", () => {
   it("uses suggestion label when executing command", () => {
-    const insertContent = vi.fn().mockReturnValue({ run: vi.fn() });
+    const calls: any[] = [];
+    const insertContent = (arg: any) => {
+      calls.push(arg);
+      return { run() {} };
+    };
     const command = SlashCommand.options.suggestion.command as any;
     command({
       editor: {
@@ -16,6 +21,27 @@ describe("slash-command extension", () => {
       range: {} as any,
       props: { label: "test" },
     });
-    expect(insertContent).toHaveBeenCalledWith("test");
+    assert.deepStrictEqual(calls, ["test"]);
+  });
+
+  it("inserts empty string when label missing", () => {
+    const calls: any[] = [];
+    const insertContent = (arg: any) => {
+      calls.push(arg);
+      return { run() {} };
+    };
+    const command = SlashCommand.options.suggestion.command as any;
+    command({
+      editor: {
+        chain: () => ({
+          focus: () => ({
+            deleteRange: () => ({ insertContent }),
+          }),
+        }),
+      },
+      range: {} as any,
+      props: {},
+    });
+    assert.deepStrictEqual(calls, [""]);
   });
 });

--- a/tests/property/tiptap_structure.test.ts
+++ b/tests/property/tiptap_structure.test.ts
@@ -1,9 +1,39 @@
-import { describe, it, expect } from "vitest";
-import { isValidStructure } from "../../extensions/tiptapStructure";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { tiptapStructure, isValidStructure } from "../../extensions/tiptapStructure.js";
 
 describe("TipTap heading structure", () => {
   it("detects consecutive headings", () => {
-    expect(isValidStructure("<h1>a</h1><h2>b</h2>")).toBe(false);
-    expect(isValidStructure("<h1>a</h1><p>p</p>")).toBe(true);
+    assert.strictEqual(isValidStructure("<h1>a</h1><h2>b</h2>"), false);
+    assert.strictEqual(isValidStructure("<h1>a</h1><p>p</p>"), true);
+    assert.strictEqual(
+      isValidStructure("<h1>a</h1><blockquote>b</blockquote>"),
+      false,
+    );
+  });
+
+  it("plugin filterTransaction enforces rules", () => {
+    const plugin = (tiptapStructure() as any).config.addProseMirrorPlugins()[0];
+    const filter = plugin.spec.filterTransaction as (tr: any) => boolean;
+    const badDoc = {
+      childCount: 2,
+      child(i: number) {
+        return [
+          { type: { name: "heading" } },
+          { type: { name: "heading" } },
+        ][i];
+      },
+    };
+    assert.strictEqual(filter({ doc: badDoc, docChanged: true } as any), false);
+    const goodDoc = {
+      childCount: 2,
+      child(i: number) {
+        return [
+          { type: { name: "heading" } },
+          { type: { name: "paragraph" } },
+        ][i];
+      },
+    };
+    assert.strictEqual(filter({ doc: goodDoc, docChanged: true } as any), true);
   });
 });

--- a/tests/property/validation.test.ts
+++ b/tests/property/validation.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
-import { validateDocument, validateTemplate } from "../../utils/validation";
-import { describe, it } from "vitest";
+import { validateDocument, validateTemplate } from "../../utils/validation.js";
+import { describe, it } from "node:test";
 
 // Property: validators should return boolean for any input without throwing
 

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,23 +1,24 @@
-import { describe, it, expect } from "vitest";
-import { sanitizeHtml } from "../../utils/sanitize";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeHtml } from "../../utils/sanitize.js";
 
 describe("sanitizeHtml", () => {
   it("removes script tags and event handlers", () => {
     const dirty = '<div onclick="alert(1)"><script>alert(2)</script>Hi</div>';
     const clean = sanitizeHtml(dirty);
-    expect(clean).toBe("<div>Hi</div>");
+    assert.strictEqual(clean, "<div>Hi</div>");
   });
 
   it("strips javascript and data URLs", () => {
     const dirty =
       '<a href="javascript:alert(1)" src="data:text/html;base64,AAAA">link</a>';
     const clean = sanitizeHtml(dirty);
-    expect(clean).toBe("<a>link</a>");
+    assert.strictEqual(clean, "<a>link</a>");
   });
 
   it("blocks other dangerous schemes like vbscript", () => {
     const dirty = '<a href="vbscript:evil">x</a>';
     const clean = sanitizeHtml(dirty);
-    expect(clean).toBe("<a>x</a>");
+    assert.strictEqual(clean, "<a>x</a>");
   });
 });

--- a/tests/utils/templateIntegration.test.ts
+++ b/tests/utils/templateIntegration.test.ts
@@ -1,22 +1,23 @@
-import { describe, it, expect } from "vitest";
-import { integrateTemplates } from "../../utils/templateIntegration";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { integrateTemplates } from "../../utils/templateIntegration.js";
 
 describe("integrateTemplates", () => {
   it("filters invalid templates", () => {
     const input = [{ title: "A", body: "b" }, { title: "bad" }, null];
     const result = integrateTemplates(input as any);
-    expect(result).toEqual([{ title: "A", body: "b" }]);
+    assert.deepStrictEqual(result, [{ title: "A", body: "b" }]);
   });
 
   it("throws for non-array input", () => {
     // invalid input passed intentionally
-    expect(() => integrateTemplates(null as any)).toThrow(TypeError);
+    assert.throws(() => integrateTemplates(null as any), TypeError);
   });
 
   it("strips extraneous fields and returns new objects", () => {
     const tpl: any = { title: "A", body: "b", evil: "x" };
     const [result] = integrateTemplates([tpl]);
-    expect(result).toEqual({ title: "A", body: "b" });
-    expect(result).not.toBe(tpl);
+    assert.deepStrictEqual(result, { title: "A", body: "b" });
+    assert.notStrictEqual(result, tpl);
   });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,36 +1,37 @@
-import { describe, it, expect } from "vitest";
-import { validateDocument, validateTemplate } from "../../utils/validation";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { validateDocument, validateTemplate } from "../../utils/validation.js";
 
 describe("validateDocument", () => {
   it("returns true for objects with content string", () => {
-    expect(validateDocument({ content: "a" })).toBe(true);
+    assert.strictEqual(validateDocument({ content: "a" }), true);
   });
 
   it("returns false otherwise", () => {
-    expect(validateDocument({})).toBe(false);
-    expect(validateDocument(null)).toBe(false);
+    assert.strictEqual(validateDocument({}), false);
+    assert.strictEqual(validateDocument(null), false);
     const arr: any = [];
     arr.content = "x";
-    expect(validateDocument(arr)).toBe(false);
+    assert.strictEqual(validateDocument(arr), false);
     // should not accept properties from the prototype chain
     const protoDoc = Object.create({ content: "p" });
-    expect(validateDocument(protoDoc)).toBe(false);
+    assert.strictEqual(validateDocument(protoDoc), false);
   });
 });
 
 describe("validateTemplate", () => {
   it("returns true for objects with title and body", () => {
-    expect(validateTemplate({ title: "t", body: "b" })).toBe(true);
+    assert.strictEqual(validateTemplate({ title: "t", body: "b" }), true);
   });
 
   it("returns false otherwise", () => {
-    expect(validateTemplate({ title: "t" })).toBe(false);
-    expect(validateTemplate(null)).toBe(false);
+    assert.strictEqual(validateTemplate({ title: "t" }), false);
+    assert.strictEqual(validateTemplate(null), false);
     const arr: any = [];
     arr.title = "t";
     arr.body = "b";
-    expect(validateTemplate(arr)).toBe(false);
+    assert.strictEqual(validateTemplate(arr), false);
     const protoTpl = Object.create({ title: "t", body: "b" });
-    expect(validateTemplate(protoTpl)).toBe(false);
+    assert.strictEqual(validateTemplate(protoTpl), false);
   });
 });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "build",
+    "module": "node16",
+    "target": "es2022",
+    "types": ["node"],
+    "isolatedModules": false,
+    "moduleResolution": "node16"
+  },
+  "include": [
+    "utils/**/*.ts",
+    "extensions/slash-command.ts",
+    "extensions/tiptapStructure.ts",
+    "tests/utils/**/*.ts",
+    "tests/extensions/**/*.ts",
+    "tests/property/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -2,24 +2,27 @@
  * Basic HTML sanitizer removing script tags and event handler attributes.
  * This prevents template content from executing arbitrary JavaScript.
  */
+import { JSDOM } from "jsdom";
+
 export function sanitizeHtml(html: string): string {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, "text/html");
+  const Parser =
+    typeof DOMParser !== "undefined" ? DOMParser : new JSDOM("").window.DOMParser;
+  const doc = new Parser().parseFromString(html, "text/html");
   // Remove all script tags
   doc.querySelectorAll("script").forEach((el) => el.remove());
   // Remove event handler attributes like onclick
   doc.querySelectorAll("*").forEach((el) => {
-    for (const attr of Array.from(el.attributes)) {
-      const name = attr.name.toLowerCase();
+    for (const attribute of Array.from(el.attributes) as Attr[]) {
+      const name = attribute.name.toLowerCase();
       if (name.startsWith("on")) {
-        el.removeAttribute(attr.name);
+        el.removeAttribute(attribute.name);
         continue;
       }
       if (
         (name === "href" || name === "src") &&
-        /^(javascript|data|vbscript):/i.test(attr.value.trim())
+        /^(javascript|data|vbscript):/i.test(attribute.value.trim())
       ) {
-        el.removeAttribute(attr.name);
+        el.removeAttribute(attribute.name);
       }
     }
   });

--- a/utils/templateIntegration.ts
+++ b/utils/templateIntegration.ts
@@ -1,4 +1,4 @@
-import { validateTemplate } from "./validation";
+import { validateTemplate } from "./validation.js";
 
 export interface Template {
   title: string;


### PR DESCRIPTION
## Summary
- allow sanitization and structure validation to run in Node by falling back to JSDOM when DOMParser isn't available
- prevent slash-command from inserting undefined labels
- tighten heading structure rules and exercise plugin behaviour in tests

## Testing
- `npx tsc -p tsconfig.test.json`
- `NODE_V8_COVERAGE=coverage node --test --experimental-test-coverage build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ad9895879c83328621f1213c73838d