### PR TITLE
Enhance validation and sanitization tests

### DIFF
--- a/tests/components/CommentTrack.test.tsx
+++ b/tests/components/CommentTrack.test.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import CommentTrack from "../../components/CommentTrack";
 import { render, screen, fireEvent } from "@testing-library/react";
+import CommentTrack from "../../components/CommentTrack";
 
-describe.skip("CommentTrack", () => {
+describe("CommentTrack", () => {
   it("adds comments", () => {
     render(<CommentTrack />);
     const input = screen.getByPlaceholderText(/enter comment/i);
     fireEvent.change(input, { target: { value: "hello" } });
     fireEvent.click(screen.getByText("Add"));
-    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("hello").textContent).toBe("hello");
   });
 });

--- a/tests/components/HeadingStylePresets.test.tsx
+++ b/tests/components/HeadingStylePresets.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import HeadingStylePresets from "../../components/HeadingStylePresets";
 import { render, screen, fireEvent } from "@testing-library/react";
+import HeadingStylePresets from "../../components/HeadingStylePresets";
 
-describe.skip("HeadingStylePresets", () => {
+describe("HeadingStylePresets", () => {
   it("invokes callback", () => {
     const cb = vi.fn();
     render(<HeadingStylePresets onSelect={cb} />);

--- a/tests/components/ModernLayout.test.tsx
+++ b/tests/components/ModernLayout.test.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { describe, it, expect, vi } from "vitest";
-import ModernLayout from "../../components/ModernLayout";
 import { render, screen } from "@testing-library/react";
+import ModernLayout from "../../components/ModernLayout";
 
-describe.skip("ModernLayout", () => {
+describe("ModernLayout", () => {
   it("renders children", () => {
     render(
       <ModernLayout>
         <span>child</span>
       </ModernLayout>,
     );
-    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.getByText("child").textContent).toBe("child");
   });
 });

--- a/tests/components/ValidationStatus.test.tsx
+++ b/tests/components/ValidationStatus.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
-import ValidationStatus from "../../components/ValidationStatus";
 import { render, screen } from "@testing-library/react";
+import ValidationStatus from "../../components/ValidationStatus";
 
-describe.skip("ValidationStatus", () => {
+describe("ValidationStatus", () => {
   it("renders results", () => {
     render(
       <ValidationStatus
@@ -11,6 +11,6 @@ describe.skip("ValidationStatus", () => {
         onClear={() => {}}
       />,
     );
-    expect(screen.getByText(/A/)).toBeInTheDocument();
+    expect(screen.getByText(/A:/).textContent).toContain("A:");
   });
 });

--- a/tests/extensions/slash-command.test.ts
+++ b/tests/extensions/slash-command.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import SlashCommand from "../../extensions/slash-command.js";
 

--- a/tests/property/tiptap_structure.test.ts
+++ b/tests/property/tiptap_structure.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { tiptapStructure, isValidStructure } from "../../extensions/tiptapStructure.js";
 

--- a/tests/property/validation.test.ts
+++ b/tests/property/validation.test.ts
@@ -1,6 +1,6 @@
 import fc from "fast-check";
 import { validateDocument, validateTemplate } from "../../utils/validation.js";
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 
 // Property: validators should return boolean for any input without throwing
 

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it, expect } from "vitest";
 import assert from "node:assert/strict";
 import { sanitizeHtml } from "../../utils/sanitize.js";
 
@@ -20,5 +20,12 @@ describe("sanitizeHtml", () => {
     const dirty = '<a href="vbscript:evil">x</a>';
     const clean = sanitizeHtml(dirty);
     assert.strictEqual(clean, "<a>x</a>");
+  });
+
+  it("removes dangerous CSS expressions", () => {
+    const dirty =
+      '<div style="color:red; width:expression(alert(1)); background:url(javascript:evil)">x</div>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, "<div>x</div>");
   });
 });

--- a/tests/utils/templateIntegration.test.ts
+++ b/tests/utils/templateIntegration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { integrateTemplates } from "../../utils/templateIntegration.js";
 

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "node:test";
+import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { validateDocument, validateTemplate } from "../../utils/validation.js";
 
@@ -17,6 +17,11 @@ describe("validateDocument", () => {
     const protoDoc = Object.create({ content: "p" });
     assert.strictEqual(validateDocument(protoDoc), false);
   });
+
+  it("rejects empty content", () => {
+    assert.strictEqual(validateDocument({ content: "" }), false);
+    assert.strictEqual(validateDocument({ content: "   " }), false);
+  });
 });
 
 describe("validateTemplate", () => {
@@ -33,5 +38,12 @@ describe("validateTemplate", () => {
     assert.strictEqual(validateTemplate(arr), false);
     const protoTpl = Object.create({ title: "t", body: "b" });
     assert.strictEqual(validateTemplate(protoTpl), false);
+  });
+
+  it("rejects empty strings", () => {
+    assert.strictEqual(validateTemplate({ title: "", body: "b" }), false);
+    assert.strictEqual(validateTemplate({ title: "t", body: "" }), false);
+    assert.strictEqual(validateTemplate({ title: " ", body: "b" }), false);
+    assert.strictEqual(validateTemplate({ title: "t", body: "   " }), false);
   });
 });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -18,6 +18,16 @@ export function sanitizeHtml(html: string): string {
         el.removeAttribute(attribute.name);
         continue;
       }
+      if (name === "style") {
+        const val = attribute.value.toLowerCase();
+        if (
+          /expression\s*\(/i.test(val) ||
+          /url\s*\(\s*(javascript|data|vbscript):/i.test(val)
+        ) {
+          el.removeAttribute(attribute.name);
+          continue;
+        }
+      }
       if (
         (name === "href" || name === "src") &&
         /^(javascript|data|vbscript):/i.test(attribute.value.trim())

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -10,7 +10,8 @@ export function validateDocument(doc: unknown): boolean {
   const rec = doc as Record<string, unknown>;
   return (
     Object.prototype.hasOwnProperty.call(rec, "content") &&
-    typeof rec.content === "string"
+    typeof rec.content === "string" &&
+    rec.content.trim().length > 0
   );
 }
 
@@ -28,6 +29,8 @@ export function validateTemplate(tpl: unknown): boolean {
     Object.prototype.hasOwnProperty.call(rec, "title") &&
     Object.prototype.hasOwnProperty.call(rec, "body") &&
     typeof rec.title === "string" &&
-    typeof rec.body === "string"
+    rec.title.trim().length > 0 &&
+    typeof rec.body === "string" &&
+    rec.body.trim().length > 0
   );
 }


### PR DESCRIPTION
## Summary
- Harden validation utilities to reject blank strings
- Extend HTML sanitizer to drop dangerous CSS expressions
- Enable and convert previously skipped tests to run under Vitest

## Testing
- `npx vitest run`
- `node scripts/coverage-summary.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68adb0d999d88332a01a05daadbae327