### PR TITLE
Improve sanitization and validation robustness

### DIFF
--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,52 +1,55 @@
 import fs from 'fs';
 import path from 'path';
 
-function mergeCoverage(dir) {
-  const map = new Map();
-  for (const file of fs.readdirSync(dir)) {
-    const json = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
-    for (const result of json.result) {
-      if (!result.url.startsWith('file://')) continue;
-      const filepath = result.url.replace('file://', '');
-      const cwd = process.cwd();
-      if (
-        !filepath.startsWith(path.join(cwd, 'utils')) &&
-        !filepath.startsWith(path.join(cwd, 'tests'))
-      ) {
-        continue;
-      }
-    const info = map.get(filepath) || [];
-      for (const fn of result.functions) {
-        for (const range of fn.ranges) info.push(range);
-      }
-      map.set(filepath, info);
+const coverageDir = path.resolve('./coverage');
+const files = fs.readdirSync(coverageDir).filter(f => f.endsWith('.json'));
+const fileCoverage = new Map();
+const projectDir = path.resolve('.');
+
+function markLines(url, start, end, content){
+  if(!fileCoverage.has(url)){
+    const lines = content.split('\n').map(()=>({covered:false, text:''}));
+    lines.forEach((_,i)=>{ lines[i].text = content.split('\n')[i]; });
+    fileCoverage.set(url, lines);
+  }
+  const arr = fileCoverage.get(url);
+  // Precompute line start offsets
+  const lineOffsets = []; let offset=0; const lines=content.split('\n');
+  for(const line of lines){ lineOffsets.push(offset); offset += line.length+1; }
+  for(let i=0;i<lines.length;i++){
+    const lineStart=lineOffsets[i];
+    const lineEnd=i===lines.length-1?content.length:lineOffsets[i+1];
+    if(Math.min(end,lineEnd) > Math.max(start,lineStart)){
+      arr[i].covered = true;
     }
   }
-  return map;
 }
 
-function rangeCoverage(ranges) {
-  const uniq = new Map();
-  for (const r of ranges) {
-    const key = r.startOffset + ':' + r.endOffset;
-    const existing = uniq.get(key) || { start: r.startOffset, end: r.endOffset, count: 0 };
-    if (r.count > 0) existing.count = r.count;
-    uniq.set(key, existing);
+for(const file of files){
+  const data = JSON.parse(fs.readFileSync(path.join(coverageDir,file),'utf8'));
+  for(const script of data.result){
+    if(!script.url.startsWith('file://')) continue;
+    const filePath = new URL(script.url).pathname;
+    if(!filePath.startsWith(path.join(projectDir, 'utils'))) continue;
+    const content = fs.readFileSync(filePath,'utf8');
+    for(const fn of script.functions){
+      for(const range of fn.ranges){
+        if(range.count>0){
+          markLines(filePath, range.startOffset, range.endOffset, content);
+        }
+      }
+    }
   }
-  let total = 0, covered = 0;
-  for (const r of uniq.values()) {
-    total++;
-    if (r.count > 0) covered++;
-  }
-  return { total, covered, pct: (covered / total) * 100 };
 }
 
-const map = mergeCoverage('.cov');
-let totalCovered = 0, total = 0;
-for (const [file, ranges] of map.entries()) {
-  const { covered, total: t, pct } = rangeCoverage(ranges);
-  totalCovered += covered;
-  total += t;
-  console.log(`${file} -> ${pct.toFixed(2)}% (${covered}/${t})`);
+let total=0, covered=0;
+for(const [url, lines] of fileCoverage.entries()){
+  const filtered = lines.filter(l => l.text.trim() !== '');
+  const fileCovered = filtered.filter(l=>l.covered).length;
+  const fileTotal = filtered.length;
+  total += fileTotal; covered += fileCovered;
+  const pct = ((fileCovered/fileTotal)*100).toFixed(2);
+  console.log(`${path.relative('.', url)}: ${fileCovered}/${fileTotal} (${pct}%)`);
 }
-console.log(`TOTAL -> ${(totalCovered / total * 100).toFixed(2)}% (${totalCovered}/${total})`);
+const pctTotal = ((covered/total)*100).toFixed(2);
+console.log(`TOTAL: ${covered}/${total} (${pctTotal}%)`);

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -35,6 +35,19 @@ describe("sanitizeHtml", () => {
     assert.strictEqual(clean, "<a>x</a>");
   });
 
+  it("strips schemes split by whitespace", () => {
+    const dirty = '<a href="java\nscript:alert(1)">x</a>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, "<a>x</a>");
+  });
+
+  it("removes quoted javascript urls in style attributes", () => {
+    const dirty =
+      '<div style="background:url(\'javascript:evil\')">x</div>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, "<div>x</div>");
+  });
+
   it("removes dangerous srcset entries", () => {
     const dirty = '<img srcset="javascript:alert(1) 1x, http://e/x.png 2x">';
     const clean = sanitizeHtml(dirty);

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -22,6 +22,16 @@ describe("validateDocument", () => {
     assert.strictEqual(validateDocument({ content: "" }), false);
     assert.strictEqual(validateDocument({ content: "   " }), false);
   });
+
+  it("returns false when content getter throws", () => {
+    const doc: any = {};
+    Object.defineProperty(doc, "content", {
+      get() {
+        throw new Error("boom");
+      },
+    });
+    assert.strictEqual(validateDocument(doc), false);
+  });
 });
 
 describe("validateTemplate", () => {
@@ -49,5 +59,20 @@ describe("validateTemplate", () => {
     assert.strictEqual(validateTemplate({ title: "t", body: "" }), false);
     assert.strictEqual(validateTemplate({ title: " ", body: "b" }), false);
     assert.strictEqual(validateTemplate({ title: "t", body: "   " }), false);
+  });
+
+  it("returns false when property getters throw", () => {
+    const tpl: any = {};
+    Object.defineProperty(tpl, "title", {
+      get() {
+        throw new Error("nope");
+      },
+    });
+    Object.defineProperty(tpl, "body", {
+      get() {
+        throw new Error("nope");
+      },
+    });
+    assert.strictEqual(validateTemplate(tpl), false);
   });
 });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -20,9 +20,10 @@ export function sanitizeHtml(html: string): string {
       }
       if (name === "style") {
         const val = attribute.value.toLowerCase();
+        // Allow optional quotes around url schemes
         if (
           /expression\s*\(/i.test(val) ||
-          /url\s*\(\s*(javascript|data|vbscript):/i.test(val)
+          /url\s*\(\s*['"]?(javascript|data|vbscript):/i.test(val)
         ) {
           el.removeAttribute(attribute.name);
           continue;
@@ -30,9 +31,10 @@ export function sanitizeHtml(html: string): string {
       }
       if (name === "srcset") {
         const entries = attribute.value.split(",");
-        const unsafe = entries.some((entry) =>
-          /^(?:javascript|data|vbscript)\s*:/i.test(entry.trim()),
-        );
+        const unsafe = entries.some((entry) => {
+          const norm = entry.replace(/[\s\u0000-\u001F]+/g, "");
+          return /^(?:javascript|data|vbscript):/i.test(norm);
+        });
         if (unsafe) {
           el.removeAttribute(attribute.name);
         }
@@ -41,7 +43,9 @@ export function sanitizeHtml(html: string): string {
 
       if (
         (name === "href" || name === "src") &&
-        /^(?:javascript|data|vbscript)\s*:/i.test(attribute.value.trim())
+        /^(?:javascript|data|vbscript):/i.test(
+          attribute.value.replace(/[\s\u0000-\u001F]+/g, ""),
+        )
       ) {
         el.removeAttribute(attribute.name);
       }

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -8,11 +8,16 @@ export function validateDocument(doc: unknown): boolean {
     return false;
   }
   const rec = doc as Record<string, unknown>;
-  return (
-    Object.prototype.hasOwnProperty.call(rec, "content") &&
-    typeof rec.content === "string" &&
-    rec.content.trim().length > 0
-  );
+  try {
+    return (
+      Object.prototype.hasOwnProperty.call(rec, "content") &&
+      typeof rec.content === "string" &&
+      rec.content.trim().length > 0
+    );
+  } catch {
+    // Accessing the property might trigger a getter that throws; treat as invalid
+    return false;
+  }
 }
 
 /**
@@ -26,12 +31,17 @@ export function validateTemplate(tpl: unknown): boolean {
     return false;
   }
   const rec = tpl as Record<string, unknown>;
-  return (
-    Object.prototype.hasOwnProperty.call(rec, "title") &&
-    Object.prototype.hasOwnProperty.call(rec, "body") &&
-    (typeof rec.title === "string" || typeof rec.title === "number") &&
-    String(rec.title).trim().length > 0 &&
-    (typeof rec.body === "string" || typeof rec.body === "number") &&
-    String(rec.body).trim().length > 0
-  );
+  try {
+    return (
+      Object.prototype.hasOwnProperty.call(rec, "title") &&
+      Object.prototype.hasOwnProperty.call(rec, "body") &&
+      (typeof rec.title === "string" || typeof rec.title === "number") &&
+      String(rec.title).trim().length > 0 &&
+      (typeof rec.body === "string" || typeof rec.body === "number") &&
+      String(rec.body).trim().length > 0
+    );
+  } catch {
+    // If accessing properties throws (e.g. getters with side effects), treat as invalid
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
- harden HTML sanitizer against quoted URLs and scheme obfuscation
- ensure validation utilities ignore throwing getters
- add coverage script and expanded tests for edge cases

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: PluginKey missing and other TS errors)*
- `NODE_V8_COVERAGE=./coverage npx vitest run`
- `node scripts/coverage-summary.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68af02600ca8833289907d12924db2a4