### PR TITLE
fix(utils): harden validation and sanitization

### DIFF
--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -53,4 +53,10 @@ describe("sanitizeHtml", () => {
     const clean = sanitizeHtml(dirty);
     assert.strictEqual(clean, "<img>");
   });
+
+  it("removes iframe elements", () => {
+    const dirty = '<iframe src="http://example.com" onload="alert(1)"></iframe>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, "");
+  });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -32,6 +32,21 @@ describe("validateDocument", () => {
     });
     assert.strictEqual(validateDocument(doc), false);
   });
+
+  it("evaluates content getter only once", () => {
+    let first = true;
+    const doc: any = {};
+    Object.defineProperty(doc, "content", {
+      get() {
+        if (first) {
+          first = false;
+          return "hello";
+        }
+        return "";
+      },
+    });
+    assert.strictEqual(validateDocument(doc), true);
+  });
 });
 
 describe("validateTemplate", () => {
@@ -74,5 +89,24 @@ describe("validateTemplate", () => {
       },
     });
     assert.strictEqual(validateTemplate(tpl), false);
+  });
+
+  it("evaluates getters once and rejects NaN", () => {
+    let first = true;
+    const tpl: any = {};
+    Object.defineProperty(tpl, "title", {
+      get() {
+        if (first) {
+          first = false;
+          return "t";
+        }
+        return "";
+      },
+    });
+    tpl.body = "b";
+    assert.strictEqual(validateTemplate(tpl), true);
+
+    assert.strictEqual(validateTemplate({ title: NaN, body: "b" }), false);
+    assert.strictEqual(validateTemplate({ title: "t", body: NaN }), false);
   });
 });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -8,8 +8,8 @@ export function sanitizeHtml(html: string): string {
   const Parser =
     typeof DOMParser !== "undefined" ? DOMParser : new JSDOM("").window.DOMParser;
   const doc = new Parser().parseFromString(html, "text/html");
-  // Remove all script tags
-  doc.querySelectorAll("script").forEach((el) => el.remove());
+  // Remove all script and iframe tags
+  doc.querySelectorAll("script, iframe").forEach((el) => el.remove());
   // Remove event handler attributes like onclick
   doc.querySelectorAll("*").forEach((el) => {
     for (const attribute of Array.from(el.attributes) as Attr[]) {

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -9,11 +9,11 @@ export function validateDocument(doc: unknown): boolean {
   }
   const rec = doc as Record<string, unknown>;
   try {
-    return (
-      Object.prototype.hasOwnProperty.call(rec, "content") &&
-      typeof rec.content === "string" &&
-      rec.content.trim().length > 0
-    );
+    if (!Object.prototype.hasOwnProperty.call(rec, "content")) {
+      return false;
+    }
+    const value = rec.content;
+    return typeof value === "string" && value.trim().length > 0;
   } catch {
     // Accessing the property might trigger a getter that throws; treat as invalid
     return false;
@@ -32,14 +32,31 @@ export function validateTemplate(tpl: unknown): boolean {
   }
   const rec = tpl as Record<string, unknown>;
   try {
-    return (
-      Object.prototype.hasOwnProperty.call(rec, "title") &&
-      Object.prototype.hasOwnProperty.call(rec, "body") &&
-      (typeof rec.title === "string" || typeof rec.title === "number") &&
-      String(rec.title).trim().length > 0 &&
-      (typeof rec.body === "string" || typeof rec.body === "number") &&
-      String(rec.body).trim().length > 0
-    );
+    if (
+      !Object.prototype.hasOwnProperty.call(rec, "title") ||
+      !Object.prototype.hasOwnProperty.call(rec, "body")
+    ) {
+      return false;
+    }
+    const title = rec.title;
+    const body = rec.body;
+    if (
+      !(
+        typeof title === "string" ||
+        (typeof title === "number" && !Number.isNaN(title))
+      )
+    ) {
+      return false;
+    }
+    if (
+      !(
+        typeof body === "string" ||
+        (typeof body === "number" && !Number.isNaN(body))
+      )
+    ) {
+      return false;
+    }
+    return String(title).trim().length > 0 && String(body).trim().length > 0;
   } catch {
     // If accessing properties throws (e.g. getters with side effects), treat as invalid
     return false;


### PR DESCRIPTION
## Summary
- guard against multiple getter evaluations in validation helpers
- reject NaN values for template titles/bodies
- strip iframe elements in HTML sanitizer
- extend tests for validation and sanitization edge cases

## Testing
- `NODE_V8_COVERAGE=coverage npm test --silent`
- `node scripts/coverage-summary.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68af0c926e188332b8525ceec40c1e13