### PR TITLE
Harden template validation and sanitization utilities

### DIFF
--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -54,6 +54,13 @@ describe("sanitizeHtml", () => {
     assert.strictEqual(clean, "<img>");
   });
 
+  it("removes xlink:href attributes with dangerous schemes", () => {
+    const dirty = '<svg><a xlink:href="javascript:alert(1)">x</a></svg>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean.includes("xlink:href"), false);
+    assert.strictEqual(clean.includes("javascript"), false);
+  });
+
   it("removes iframe elements", () => {
     const dirty = '<iframe src="http://example.com" onload="alert(1)"></iframe>';
     const clean = sanitizeHtml(dirty);

--- a/tests/utils/templateIntegration.test.ts
+++ b/tests/utils/templateIntegration.test.ts
@@ -26,4 +26,21 @@ describe("integrateTemplates", () => {
     const result = integrateTemplates(input);
     assert.deepStrictEqual(result, [{ title: "123", body: "456" }]);
   });
+
+  it("accesses template fields only once", () => {
+    let calls = 0;
+    const tpl: any = {
+      get title() {
+        calls++;
+        if (calls > 1) {
+          throw new Error("called twice");
+        }
+        return "A";
+      },
+      body: "b",
+    };
+    const result = integrateTemplates([tpl]);
+    assert.deepStrictEqual(result, [{ title: "A", body: "b" }]);
+    assert.strictEqual(calls, 1);
+  });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -109,4 +109,19 @@ describe("validateTemplate", () => {
     assert.strictEqual(validateTemplate({ title: NaN, body: "b" }), false);
     assert.strictEqual(validateTemplate({ title: "t", body: NaN }), false);
   });
+
+  it("rejects infinite numbers", () => {
+    assert.strictEqual(
+      validateTemplate({ title: Infinity, body: 1 }),
+      false,
+    );
+    assert.strictEqual(
+      validateTemplate({ title: 1, body: Infinity }),
+      false,
+    );
+    assert.strictEqual(
+      validateTemplate({ title: -Infinity, body: 1 }),
+      false,
+    );
+  });
 });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -42,7 +42,7 @@ export function sanitizeHtml(html: string): string {
       }
 
       if (
-        (name === "href" || name === "src") &&
+        (name === "href" || name === "src" || name === "xlink:href") &&
         /^(?:javascript|data|vbscript):/i.test(
           attribute.value.replace(/[\s\u0000-\u001F]+/g, ""),
         )

--- a/utils/templateIntegration.ts
+++ b/utils/templateIntegration.ts
@@ -17,11 +17,23 @@ export function integrateTemplates(templates: unknown[]): Template[] {
     throw new TypeError("templates must be an array");
   }
 
-  return templates
-    .filter(validateTemplate)
-    .map((t) => {
-      const rec = t as Record<string, unknown>;
-      return { title: String(rec.title), body: String(rec.body) };
-    });
+  const result: Template[] = [];
+  for (const tpl of templates) {
+    try {
+      if (typeof tpl !== "object" || tpl === null) {
+        continue;
+      }
+      const rec = tpl as Record<string, unknown>;
+      const title = rec.title;
+      const body = rec.body;
+      // Validate using the already-read values so getters are not invoked twice
+      if (validateTemplate({ title, body })) {
+        result.push({ title: String(title), body: String(body) });
+      }
+    } catch {
+      // Ignore entries where property access throws
+    }
+  }
+  return result;
 }
 

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -43,7 +43,7 @@ export function validateTemplate(tpl: unknown): boolean {
     if (
       !(
         typeof title === "string" ||
-        (typeof title === "number" && !Number.isNaN(title))
+        (typeof title === "number" && Number.isFinite(title))
       )
     ) {
       return false;
@@ -51,7 +51,7 @@ export function validateTemplate(tpl: unknown): boolean {
     if (
       !(
         typeof body === "string" ||
-        (typeof body === "number" && !Number.isNaN(body))
+        (typeof body === "number" && Number.isFinite(body))
       )
     ) {
       return false;


### PR DESCRIPTION
## Summary
- ensure template validation rejects non-finite numbers
- avoid double evaluation of template getters in `integrateTemplates`
- sanitize `xlink:href` attributes to block SVG JS URLs

## Testing
- `npm test`
- `NODE_V8_COVERAGE=coverage npm test`
- `node scripts/coverage-summary.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68af56fb46248332bdd5a78141b88289