### PR TITLE
Improve template validation and strengthen sanitization tests

### DIFF
--- a/scripts/v8-coverage-summary.mjs
+++ b/scripts/v8-coverage-summary.mjs
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const covDir = path.resolve('.coverage');
+const files = fs.readdirSync(covDir).filter(f => f.endsWith('.json'));
+const coverage = new Map();
+
+function getLineOffsets(src) {
+  const offsets = [0];
+  for (let i = 0; i < src.length; i++) {
+    if (src[i] === '\n') offsets.push(i + 1);
+  }
+  return offsets;
+}
+
+function offsetToLine(offset, offsets) {
+  let low = 0, high = offsets.length - 1;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid] <= offset) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  return high + 1; // line numbers are 1-indexed
+}
+
+for (const f of files) {
+  const data = JSON.parse(fs.readFileSync(path.join(covDir, f), 'utf8'));
+  for (const script of data.result) {
+    if (!script.url.startsWith('file://')) continue;
+    const filePath = fileURLToPath(script.url);
+    if (filePath.includes('node_modules') || filePath.includes('/tests/')) continue;
+    if (!fs.existsSync(filePath)) continue;
+    const ext = path.extname(filePath);
+    if (!['.ts', '.tsx', '.js', '.jsx'].includes(ext)) continue;
+    const rel = path.relative(process.cwd(), filePath);
+    let info = coverage.get(rel);
+    if (!info) {
+      const src = fs.readFileSync(filePath, 'utf8');
+      const offsets = getLineOffsets(src);
+      info = { offsets, covered: new Set() };
+      coverage.set(rel, info);
+    }
+    const { offsets, covered } = info;
+    for (const fn of script.functions) {
+      for (const range of fn.ranges) {
+        if (range.count === 0) continue;
+        const startLine = offsetToLine(range.startOffset, offsets);
+        const endLine = offsetToLine(range.endOffset - 1, offsets);
+        for (let l = startLine; l <= endLine; l++) {
+          covered.add(l);
+        }
+      }
+    }
+  }
+}
+
+let totalCovered = 0;
+let totalLines = 0;
+for (const [file, info] of coverage) {
+  const lines = info.offsets.length;
+  const cov = info.covered.size;
+  totalLines += lines;
+  totalCovered += cov;
+  const pct = ((cov / lines) * 100).toFixed(2);
+  console.log(`${pct}%\t${cov}/${lines}\t${file}`);
+}
+const totalPct = ((totalCovered / totalLines) * 100).toFixed(2);
+console.log(`TOTAL ${totalPct}% (${totalCovered}/${totalLines})`);

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -87,10 +87,28 @@ describe("sanitizeHtml", () => {
     assert.strictEqual(clean, "<div>ok</div>");
   });
 
+  it("removes meta refresh without URL", () => {
+    const dirty = '<meta http-equiv="refresh" content="5"><div>ok</div>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, "<div>ok</div>");
+  });
+
   it("strips dangerous form actions", () => {
     const dirty = '<form action="javascript:alert(1)"><input></form>';
     const clean = sanitizeHtml(dirty);
     assert.strictEqual(clean, '<form><input></form>');
+  });
+
+  it("removes formaction attributes", () => {
+    const dirty = '<button formaction="javascript:alert(1)">x</button>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, '<button>x</button>');
+  });
+
+  it("strips uppercase event handlers", () => {
+    const dirty = '<div ONCLICK="alert(1)">x</div>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, '<div>x</div>');
   });
 
   it("sanitizes inside template elements", () => {

--- a/tests/utils/templateIntegration.test.ts
+++ b/tests/utils/templateIntegration.test.ts
@@ -4,7 +4,14 @@ import { integrateTemplates } from "../../utils/templateIntegration.js";
 
 describe("integrateTemplates", () => {
   it("filters invalid templates", () => {
-    const input = [{ title: "A", body: "b" }, { title: "bad" }, null];
+    const proto = { title: "P", body: "p" };
+    const input = [
+      { title: "A", body: "b" },
+      { title: "bad" },
+      null,
+      Object.create(proto),
+      Object.assign([], { title: "x", body: "y" }),
+    ];
     const result = integrateTemplates(input as any);
     assert.deepStrictEqual(result, [{ title: "A", body: "b" }]);
   });
@@ -25,6 +32,14 @@ describe("integrateTemplates", () => {
     const input: any = [{ title: 123, body: 456 }];
     const result = integrateTemplates(input);
     assert.deepStrictEqual(result, [{ title: "123", body: "456" }]);
+  });
+
+  it("rejects arrays and prototype properties", () => {
+    const proto = { title: "t", body: "b" };
+    const arr: any = Object.assign([], { title: "x", body: "y" });
+    const obj = Object.create(proto);
+    const result = integrateTemplates([arr, obj]);
+    assert.deepStrictEqual(result, []);
   });
 
   it("accesses template fields only once", () => {

--- a/utils/templateIntegration.ts
+++ b/utils/templateIntegration.ts
@@ -20,9 +20,17 @@ export function integrateTemplates(templates: unknown[]): Template[] {
   const result: Template[] = [];
   for (const tpl of templates) {
     try {
-      if (typeof tpl !== "object" || tpl === null) {
+      // Reject non-objects, null, and arrays before touching any fields
+      if (
+        typeof tpl !== "object" ||
+        tpl === null ||
+        Array.isArray(tpl) ||
+        !Object.prototype.hasOwnProperty.call(tpl, "title") ||
+        !Object.prototype.hasOwnProperty.call(tpl, "body")
+      ) {
         continue;
       }
+
       const rec = tpl as Record<string, unknown>;
       const title = rec.title;
       const body = rec.body;


### PR DESCRIPTION
## Summary
- Reject arrays and inherited properties in template integration
- Add coverage script for v8 output
- Test HTML sanitizer for meta refresh, formaction, and uppercase events

## Testing
- `npm test -- tests/utils/templateIntegration.test.ts --run`
- `NODE_V8_COVERAGE=.coverage npm test -- --run`
- `node scripts/v8-coverage-summary.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68b24936eb308332b92009fbd5a9faa6