### PR TITLE
fix: harden sanitization and indentation

### DIFF
--- a/extensions/tiptapIndentation.ts
+++ b/extensions/tiptapIndentation.ts
@@ -11,29 +11,47 @@ import { Node as PMNode } from "prosemirror-model";
  * Adds simple indent/outdent commands by storing the level
  * in a `data-indent` attribute on paragraphs and list items.
  */
+export function getIndentLevel(editor: {
+  getAttributes: (name: string) => Record<string, unknown>;
+}): number {
+  const val = editor.getAttributes("paragraph")["data-indent"];
+  const num = typeof val === "number" ? val : Number(val);
+  return Number.isFinite(num) ? num : 0;
+}
+
+export function indentCommand({
+  editor,
+  commands,
+}: {
+  editor: any;
+  commands: any;
+}): any {
+  const level = getIndentLevel(editor);
+  return commands.updateAttributes("paragraph", {
+    "data-indent": level + 1,
+  });
+}
+
+export function outdentCommand({
+  editor,
+  commands,
+}: {
+  editor: any;
+  commands: any;
+}): any {
+  const level = getIndentLevel(editor);
+  return commands.updateAttributes("paragraph", {
+    "data-indent": Math.max(0, level - 1),
+  });
+}
+
 export function tiptapIndentation() {
   return Extension.create({
     name: "indentation",
     addCommands() {
       return {
-        indent:
-          () =>
-          ({ editor, commands }: { editor: any; commands: any }) => {
-            const level =
-              (editor.getAttributes("paragraph")["data-indent"] as number) || 0;
-            return commands.updateAttributes("paragraph", {
-              "data-indent": level + 1,
-            });
-          },
-        outdent:
-          () =>
-          ({ editor, commands }: { editor: any; commands: any }) => {
-            const level =
-              (editor.getAttributes("paragraph")["data-indent"] as number) || 0;
-            return commands.updateAttributes("paragraph", {
-              "data-indent": Math.max(0, level - 1),
-            });
-          },
+        indent: () => indentCommand,
+        outdent: () => outdentCommand,
       } as Partial<RawCommands>;
     },
     addGlobalAttributes() {

--- a/tests/extensions/indentation.edge.test.ts
+++ b/tests/extensions/indentation.edge.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { indentCommand, outdentCommand } from "../../extensions/tiptapIndentation";
+
+describe("tiptapIndentation", () => {
+  it("increments numeric indent when attribute is a string", () => {
+    const updateAttributes = vi.fn();
+    indentCommand({
+      editor: { getAttributes: () => ({ "data-indent": "2" }) },
+      commands: { updateAttributes },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith("paragraph", { "data-indent": 3 });
+  });
+
+  it("does not decrement below zero", () => {
+    const updateAttributes = vi.fn();
+    outdentCommand({
+      editor: { getAttributes: () => ({ "data-indent": "0" }) },
+      commands: { updateAttributes },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith("paragraph", { "data-indent": 0 });
+  });
+});

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import assert from "node:assert/strict";
-import { sanitizeHtml } from "../../utils/sanitize.js";
+import { JSDOM } from "jsdom";
+import { sanitizeHtml, sanitizeNode } from "../../utils/sanitize.js";
 
 describe("sanitizeHtml", () => {
   it("removes script tags and event handlers", () => {
@@ -91,6 +92,14 @@ describe("sanitizeHtml", () => {
     const dirty = '<meta http-equiv="refresh" content="5"><div>ok</div>';
     const clean = sanitizeHtml(dirty);
     assert.strictEqual(clean, "<div>ok</div>");
+  });
+
+  it("removes meta refresh with safe URL", () => {
+    const dom = new JSDOM(
+      '<meta http-equiv="refresh" content="0;url=/safe"><div>ok</div>',
+    );
+    sanitizeNode(dom.window.document);
+    expect(dom.window.document.querySelector("meta[http-equiv]")).toBeNull();
   });
 
   it("strips dangerous form actions", () => {

--- a/tests/utils/templateIntegration.test.ts
+++ b/tests/utils/templateIntegration.test.ts
@@ -34,6 +34,12 @@ describe("integrateTemplates", () => {
     assert.deepStrictEqual(result, [{ title: "123", body: "456" }]);
   });
 
+  it("trims whitespace from fields", () => {
+    const input: any = [{ title: "  A  ", body: " b  " }];
+    const result = integrateTemplates(input);
+    assert.deepStrictEqual(result, [{ title: "A", body: "b" }]);
+  });
+
   it("rejects arrays and prototype properties", () => {
     const proto = { title: "t", body: "b" };
     const arr: any = Object.assign([], { title: "x", body: "y" });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -4,7 +4,7 @@
  */
 import { JSDOM } from "jsdom";
 
-function sanitizeNode(root: ParentNode): void {
+export function sanitizeNode(root: ParentNode): void {
   // Remove tags that can execute scripts or modify document navigation
   root
     .querySelectorAll("script, iframe, object, embed, base")
@@ -13,12 +13,8 @@ function sanitizeNode(root: ParentNode): void {
   root.querySelectorAll("meta[http-equiv]").forEach((el) => {
     const equiv = el.getAttribute("http-equiv");
     if (equiv && equiv.toLowerCase() === "refresh") {
-      const content = el.getAttribute("content") || "";
-      const norm = content.replace(/[\s\u0000-\u001F]+/g, "").toLowerCase();
-      const urlIndex = norm.indexOf("url=");
-      if (urlIndex === -1 || /^(?:javascript|data|vbscript):/.test(norm.slice(urlIndex + 4))) {
-        el.remove();
-      }
+      // Refresh tags can trigger unwanted redirects even with supposedly safe URLs
+      el.remove();
     }
   });
   // Recursively process <template> contents

--- a/utils/templateIntegration.ts
+++ b/utils/templateIntegration.ts
@@ -36,7 +36,10 @@ export function integrateTemplates(templates: unknown[]): Template[] {
       const body = rec.body;
       // Validate using the already-read values so getters are not invoked twice
       if (validateTemplate({ title, body })) {
-        result.push({ title: String(title), body: String(body) });
+        result.push({
+          title: String(title).trim(),
+          body: String(body).trim(),
+        });
       }
     } catch {
       // Ignore entries where property access throws


### PR DESCRIPTION
## Summary
- sanitize meta refresh tags regardless of URL and expose `sanitizeNode`
- normalize template fields by trimming whitespace
- fix indentation command to handle string levels correctly

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: PluginKey type missing, lucide-react icons, chained commands typings)*
- `NODE_V8_COVERAGE=.coverage npm test --silent`
- `node scripts/v8-coverage-summary.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68b24b8894608332a83ac38ed4a149fc