### PR TITLE
fix(utils): harden HTML sanitizer

### DIFF
--- a/scripts/coverage.js
+++ b/scripts/coverage.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import path from 'path';
+
+const coverageDir = process.argv[2] || 'v8-coverage';
+const root = process.cwd();
+
+function lineOffsets(source) {
+  const offsets = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source[i] === '\n') offsets.push(i + 1);
+  }
+  return offsets;
+}
+
+function offsetToLine(offset, offsets) {
+  let low = 0, high = offsets.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (offsets[mid] <= offset) low = mid + 1; else high = mid - 1;
+  }
+  return high + 1; // 1-indexed line number
+}
+
+const files = new Map();
+for (const file of fs.readdirSync(coverageDir)) {
+  const data = JSON.parse(fs.readFileSync(path.join(coverageDir, file), 'utf8'));
+  for (const script of data.result) {
+    if (!script.url.startsWith('file://')) continue;
+    const filepath = script.url.replace('file://', '');
+    if (!filepath.startsWith(root + '/utils/')) continue;
+    const rel = filepath.slice(root.length + 1);
+    if (!files.has(rel)) {
+      const src = fs.readFileSync(filepath, 'utf8');
+      files.set(rel, { covered: new Set(), total: src.split('\n').length, src });
+    }
+    const entry = files.get(rel);
+    const offsets = lineOffsets(entry.src);
+    for (const fn of script.functions) {
+      for (const range of fn.ranges) {
+        if (range.count === 0) continue;
+        const start = offsetToLine(range.startOffset, offsets);
+        const end = offsetToLine(range.endOffset - 1, offsets);
+        for (let l = start; l <= end; l++) entry.covered.add(l);
+      }
+    }
+  }
+}
+
+let totalLines = 0;
+let totalCovered = 0;
+for (const [file, info] of files) {
+  totalLines += info.total;
+  totalCovered += info.covered.size;
+  const pct = (info.covered.size / info.total) * 100;
+  console.log(`${file}: ${pct.toFixed(2)}% (${info.covered.size}/${info.total})`);
+}
+const percent = totalCovered / totalLines * 100;
+console.log(`Total coverage: ${percent.toFixed(2)}% (${totalCovered}/${totalLines})`);

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -12,7 +12,7 @@ export function sanitizeNode(root: ParentNode): void {
   // Remove meta refresh tags which can trigger redirects or script URLs
   root.querySelectorAll("meta[http-equiv]").forEach((el) => {
     const equiv = el.getAttribute("http-equiv");
-    if (equiv && equiv.toLowerCase() === "refresh") {
+    if (equiv && equiv.toLowerCase().trim() === "refresh") {
       // Refresh tags can trigger unwanted redirects even with supposedly safe URLs
       el.remove();
     }
@@ -30,10 +30,11 @@ export function sanitizeNode(root: ParentNode): void {
         continue;
       }
       if (name === "style") {
-        const val = attribute.value.toLowerCase();
+        const valLower = attribute.value.toLowerCase();
+        const collapsed = valLower.replace(/[\s\u0000-\u001F]+/g, "");
         if (
-          /expression\s*\(/i.test(val) ||
-          /url\s*\(\s*['"]?(javascript|data|vbscript):/i.test(val)
+          /expression\s*\(/.test(valLower) ||
+          /url\(['"]?(javascript|data|vbscript):/.test(collapsed)
         ) {
           el.removeAttribute(attribute.name);
           continue;
@@ -56,7 +57,8 @@ export function sanitizeNode(root: ParentNode): void {
           name === "src" ||
           name === "xlink:href" ||
           name === "action" ||
-          name === "formaction") &&
+          name === "formaction" ||
+          name === "background") &&
         /^(?:javascript|data|vbscript):/i.test(
           attribute.value.replace(/[\s\u0000-\u001F]+/g, ""),
         )


### PR DESCRIPTION
## Summary
- sanitize meta refresh values with trimming
- collapse CSS style URLs to catch obfuscated javascript schemes
- block `background` attribute scripts
- add coverage script using V8 data

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: PluginKey, lucide-react icons, chained command types)*
- `NODE_V8_COVERAGE=v8-coverage npm test -- --run`
- `node scripts/coverage.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6ef0b17e88332af5c4347a2962084