### PR TITLE
docs: fix spelling of behavior in Slate scenario

### DIFF
--- a/docs/scenarios/slate.md
+++ b/docs/scenarios/slate.md
@@ -1,6 +1,6 @@
 # Slate Usage Scenarios
 
-Slate's composable plugins let you build rich behaviour. Integrate the actual editor package to enable editing functionality.
+Slate's composable plugins let you build rich behavior. Integrate the actual editor package to enable editing functionality.
 
 ## Track changes
 


### PR DESCRIPTION
## Summary
- fix spelling of "behavior" in Slate scenario documentation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b78c44b018833296bb4275bbd1742f