### PR TITLE
Fix comment addition race, sanitize CSS urls with comments, and count Unicode in TrackChanges

### DIFF
--- a/components/CommentTrack.tsx
+++ b/components/CommentTrack.tsx
@@ -10,8 +10,10 @@ export default function CommentTrack() {
   const [comments, setComments] = useState<string[]>([]);
 
   function add() {
-    if (comment.trim()) {
-      setComments([...comments, comment.trim()]);
+    const trimmed = comment.trim();
+    if (trimmed) {
+      // Use functional updates to avoid stale state when called rapidly
+      setComments((prev: string[]) => [...prev, trimmed]);
       setComment("");
     }
   }

--- a/components/TrackChanges.tsx
+++ b/components/TrackChanges.tsx
@@ -11,13 +11,14 @@ export interface TrackChangesProps {
  * mounts. This is a minimal placeholder for a full track‑changes UI.
  */
 export default function TrackChanges({ content }: TrackChangesProps) {
-  // Capture the initial content on first render
-  const [initial] = useState(content);
-  // Compare current content length to the captured initial length to determine
-  // simple added/removed character counts. This avoids diff algorithms while
-  // providing basic insight into editing activity.
-  const added = Math.max(0, content.length - initial.length);
-  const removed = Math.max(0, initial.length - content.length);
+  // Capture the initial content length using Unicode code points
+  const initialLen = useState<number>(() => Array.from(content).length)[0];
+  const currentLen = Array.from(content).length;
+  // Compare current length to the captured initial length to determine
+  // simple added/removed character counts while correctly handling emojis and
+  // other astral symbols represented by surrogate pairs.
+  const added = Math.max(0, currentLen - initialLen);
+  const removed = Math.max(0, initialLen - currentLen);
 
   if (added === 0 && removed === 0) return null;
 

--- a/tests/components/CommentTrack.test.tsx
+++ b/tests/components/CommentTrack.test.tsx
@@ -25,4 +25,17 @@ describe("CommentTrack", () => {
     const items = screen.getAllByRole("listitem").map((li) => li.textContent);
     expect(items).toEqual(["one", "two"]);
   });
+
+  it("avoids losing comments on concurrent adds", () => {
+    render(<CommentTrack />);
+    const input = screen.getByPlaceholderText(/enter comment/i) as HTMLInputElement;
+    const button = screen.getByText("Add");
+    fireEvent.change(input, { target: { value: "hi" } });
+    act(() => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+  });
 });

--- a/tests/components/TrackChanges.test.tsx
+++ b/tests/components/TrackChanges.test.tsx
@@ -21,4 +21,10 @@ describe("TrackChanges", () => {
     const node = container.querySelector('[data-testid="track-changes"]');
     expect(node).toBeNull();
   });
+
+  it("counts unicode characters correctly", () => {
+    const { rerender } = render(<TrackChanges content="😀" />);
+    rerender(<TrackChanges content="" />);
+    expect(screen.getByTestId("removed").textContent).toContain("1");
+  });
 });

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -158,4 +158,11 @@ describe("sanitizeHtml", () => {
     const clean = sanitizeHtml(dirty);
     assert.strictEqual(clean, '<div><template><div></div></template></div>');
   });
+
+  it("removes javascript urls in style even with comments", () => {
+    const dirty =
+      '<div style="background:url(/**/javascript:alert(1))">x</div>';
+    const clean = sanitizeHtml(dirty);
+    assert.strictEqual(clean, '<div>x</div>');
+  });
 });

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -30,7 +30,9 @@ export function sanitizeNode(root: ParentNode): void {
         continue;
       }
       if (name === "style") {
-        const valLower = attribute.value.toLowerCase();
+        // Strip CSS comments before checking for dangerous patterns
+        const stripped = attribute.value.replace(/\/\*[^]*?\*\//g, "");
+        const valLower = stripped.toLowerCase();
         const collapsed = valLower.replace(/[\s\u0000-\u001F]+/g, "");
         if (
           /expression\s*\(/.test(valLower) ||


### PR DESCRIPTION
## Summary
- prevent CommentTrack from dropping messages during rapid adds
- strip CSS comments before validating style URLs
- count Unicode code points in TrackChanges for accurate diffing
- add tests for concurrent adds, CSS comment sanitization, and emoji counts

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: numerous existing TS errors in stubs and pages)*
- `NODE_V8_COVERAGE=.coverage npx vitest run`
- `node scripts/v8-coverage-summary.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68baafc7584483329eef9276c687dd1f