### PR TITLE
Harden template handling and meta refresh sanitization

### DIFF
--- a/scripts/coverage-summary.js
+++ b/scripts/coverage-summary.js
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+
+const dir = process.argv[2] || 'node_v8_coverage';
+const cwd = process.cwd();
+
+function getLineStarts(source) {
+  const starts = [0];
+  let index = 0;
+  for (const line of source.split(/\n/)) {
+    index += line.length + 1; // assume \n as line ending
+    starts.push(index);
+  }
+  return starts;
+}
+
+function offsetToLine(starts, offset) {
+  let low = 0;
+  let high = starts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (starts[mid] <= offset) low = mid + 1;
+    else high = mid - 1;
+  }
+  return high + 1; // lines are 1-indexed
+}
+
+const fileData = new Map();
+
+for (const file of fs.readdirSync(dir)) {
+  const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+  for (const script of data.result) {
+    let url = script.url;
+    if (url.startsWith('file://')) url = url.slice('file://'.length);
+    if (!url.startsWith(cwd) || url.includes('node_modules')) continue;
+    const filePath = path.resolve(url);
+    if (!fs.existsSync(filePath)) continue;
+    let entry = fileData.get(filePath);
+    if (!entry) {
+      const source = fs.readFileSync(filePath, 'utf8');
+      const lines = source.split(/\n/);
+      const nonEmpty = new Set();
+      lines.forEach((l, i) => {
+        if (l.trim() !== '') nonEmpty.add(i + 1);
+      });
+      entry = {
+        starts: getLineStarts(source),
+        nonEmpty,
+        covered: new Set(),
+      };
+      fileData.set(filePath, entry);
+    }
+    const { starts, covered } = entry;
+    for (const fn of script.functions) {
+      for (const range of fn.ranges) {
+        if (range.count === 0) continue;
+        const startLine = offsetToLine(starts, range.startOffset);
+        const endLine = offsetToLine(starts, range.endOffset - 1);
+        for (let i = startLine; i <= endLine; i++) covered.add(i);
+      }
+    }
+  }
+}
+
+let total = 0;
+let coveredTotal = 0;
+for (const [filePath, { nonEmpty, covered }] of fileData.entries()) {
+  const fileCovered = [...covered].filter((l) => nonEmpty.has(l)).length;
+  const fileTotal = nonEmpty.size;
+  total += fileTotal;
+  coveredTotal += fileCovered;
+  const pct = ((fileCovered / fileTotal) * 100).toFixed(2);
+  console.log(`${path.relative(cwd, filePath)}: ${fileCovered}/${fileTotal} (${pct}%)`);
+}
+const overall = ((coveredTotal / total) * 100).toFixed(2);
+console.log(`TOTAL: ${coveredTotal}/${total} (${overall}%)`);

--- a/tests/components/TemplateLoader.test.tsx
+++ b/tests/components/TemplateLoader.test.tsx
@@ -57,4 +57,23 @@ describe("TemplateLoader", () => {
     expect(options.filter((t) => t === "One").length).toBe(1);
     expect(options).not.toContain("Bad");
   });
+
+  it("trims whitespace and rejects blank values", () => {
+    const noisy: any = [
+      { label: "  One  ", filename: "  one.html  " },
+      { label: "   ", filename: "two.html" }, // blank label
+      { label: "Two", filename: "   " }, // blank filename
+      { label: "One", filename: "one.html" }, // duplicate after trimming
+    ];
+    render(
+      <TemplateLoader templates={noisy} onLoad={() => {}} onClear={() => {}} />,
+    );
+    const opts = screen
+      .getAllByRole("option")
+      .filter((o) => o.value !== "" && o.value !== "__clear__");
+    // Only one valid template should remain and values should be trimmed
+    expect(opts).toHaveLength(1);
+    expect(opts[0].value).toBe("one.html");
+    expect(opts[0].textContent).toBe("One");
+  });
 });

--- a/tests/utils/sanitize.test.ts
+++ b/tests/utils/sanitize.test.ts
@@ -109,6 +109,15 @@ describe("sanitizeHtml", () => {
     assert.strictEqual(clean, "<div>ok</div>");
   });
 
+  it("removes meta refresh with internal whitespace", () => {
+    const dom = new JSDOM(
+      '<meta http-equiv="re fres h" content="0;url=javascript:alert(1)"><div>ok</div>',
+      { url: "http://localhost" },
+    );
+    sanitizeNode(dom.window.document);
+    expect(dom.window.document.querySelector("meta")).toBeNull();
+  });
+
   it("strips meta refresh added programmatically with spaces", () => {
     const dom = new JSDOM("<div>ok</div>", { url: "http://localhost" });
     const meta = dom.window.document.createElement("meta");

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -47,6 +47,19 @@ describe("validateDocument", () => {
     });
     assert.strictEqual(validateDocument(doc), true);
   });
+
+  it("accepts String objects", () => {
+    const doc: any = { content: new String("hi") };
+    assert.strictEqual(validateDocument(doc), true);
+    assert.strictEqual(
+      validateDocument({ content: new String("") as any }),
+      false,
+    );
+    assert.strictEqual(
+      validateTemplate({ title: new String("t"), body: new String("b") }),
+      true,
+    );
+  });
 });
 
 describe("validateTemplate", () => {

--- a/utils/sanitize.ts
+++ b/utils/sanitize.ts
@@ -12,7 +12,9 @@ export function sanitizeNode(root: ParentNode): void {
   // Remove meta refresh tags which can trigger redirects or script URLs
   root.querySelectorAll("meta[http-equiv]").forEach((el) => {
     const equiv = el.getAttribute("http-equiv");
-    if (equiv && equiv.toLowerCase().trim() === "refresh") {
+    // Some browsers are tolerant of stray whitespace inside the value, so we
+    // normalise by removing all whitespace characters before comparison.
+    if (equiv && equiv.toLowerCase().replace(/\s+/g, "") === "refresh") {
       // Refresh tags can trigger unwanted redirects even with supposedly safe URLs
       el.remove();
     }

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -13,7 +13,11 @@ export function validateDocument(doc: unknown): boolean {
       return false;
     }
     const value = rec.content;
-    return typeof value === "string" && value.trim().length > 0;
+    // Accept both primitive strings and String objects
+    if (typeof value === "string" || value instanceof String) {
+      return value.toString().trim().length > 0;
+    }
+    return false;
   } catch {
     // Accessing the property might trigger a getter that throws; treat as invalid
     return false;
@@ -40,23 +44,17 @@ export function validateTemplate(tpl: unknown): boolean {
     }
     const title = rec.title;
     const body = rec.body;
-    if (
-      !(
-        typeof title === "string" ||
-        (typeof title === "number" && Number.isFinite(title))
-      )
-    ) {
+    const isStringLike = (v: unknown) =>
+      typeof v === "string" || v instanceof String;
+    const isNumberLike = (v: unknown) =>
+      typeof v === "number" && Number.isFinite(v);
+    if (!(isStringLike(title) || isNumberLike(title))) {
       return false;
     }
-    if (
-      !(
-        typeof body === "string" ||
-        (typeof body === "number" && Number.isFinite(body))
-      )
-    ) {
+    if (!(isStringLike(body) || isNumberLike(body))) {
       return false;
     }
-    return String(title).trim().length > 0 && String(body).trim().length > 0;
+    return title.toString().trim().length > 0 && body.toString().trim().length > 0;
   } catch {
     // If accessing properties throws (e.g. getters with side effects), treat as invalid
     return false;


### PR DESCRIPTION
## Summary
- normalize TemplateLoader inputs to trim whitespace and ignore duplicates or blank templates
- accept `String` objects in validation utilities and tighten meta refresh sanitization
- add coverage helper script driven by V8 coverage output

## Testing
- `npm test`
- `NODE_V8_COVERAGE=node_v8_coverage npm test && node scripts/coverage-summary.js node_v8_coverage`

------
https://chatgpt.com/codex/tasks/task_e_68bae1db6e808332a65d39921360a30d