### PR TITLE
fix: harden template and indentation utilities

### DIFF
--- a/components/TemplateLoader.tsx
+++ b/components/TemplateLoader.tsx
@@ -46,21 +46,35 @@ export default function TemplateLoader({
   // multiple times. We now trim values and ensure they are non-empty.
   const seen = new Set<string>();
   const validTemplates = templates.reduce<TemplateMeta[]>((acc, tpl) => {
-    if (!tpl || typeof tpl.filename !== "string" || typeof tpl.label !== "string") {
-      if (tpl) {
-        console.warn("TemplateLoader: ignoring invalid template", tpl);
+    try {
+      if (!tpl || typeof tpl !== "object") {
+        if (tpl) {
+          console.warn("TemplateLoader: ignoring invalid template", tpl);
+        }
+        return acc;
       }
-      return acc;
-    }
-    const filename = tpl.filename.trim();
-    const label = tpl.label.trim();
-    const key = filename.toLowerCase();
-    if (!filename || !label || seen.has(key)) {
+
+      const rec = tpl as Record<string, unknown>;
+      const rawFilename = rec.filename;
+      const rawLabel = rec.label;
+      if (typeof rawFilename !== "string" || typeof rawLabel !== "string") {
+        console.warn("TemplateLoader: ignoring invalid template", tpl);
+        return acc;
+      }
+
+      const filename = rawFilename.trim();
+      const label = rawLabel.trim();
+      const key = filename.toLowerCase();
+      if (!filename || !label || seen.has(key)) {
+        console.warn("TemplateLoader: ignoring invalid template", tpl);
+        return acc;
+      }
+
+      seen.add(key);
+      acc.push({ label, filename });
+    } catch {
       console.warn("TemplateLoader: ignoring invalid template", tpl);
-      return acc;
     }
-    seen.add(key);
-    acc.push({ label, filename });
     return acc;
   }, []);
 

--- a/extensions/tiptapIndentation.ts
+++ b/extensions/tiptapIndentation.ts
@@ -16,7 +16,8 @@ export function getIndentLevel(editor: {
 }): number {
   const val = editor.getAttributes("paragraph")["data-indent"];
   const num = typeof val === "number" ? val : Number(val);
-  return Number.isFinite(num) ? num : 0;
+  if (!Number.isFinite(num) || num <= 0) return 0;
+  return Math.floor(num);
 }
 
 export function indentCommand({

--- a/tests/components/TemplateLoader.test.tsx
+++ b/tests/components/TemplateLoader.test.tsx
@@ -91,4 +91,25 @@ describe("TemplateLoader", () => {
     expect(opts).toHaveLength(1);
     expect(opts[0].value).toBe("DOC.html");
   });
+
+  it("accesses template fields only once", () => {
+    let calls = 0;
+    const tpl: any = {};
+    Object.defineProperty(tpl, "filename", {
+      get() {
+        calls++;
+        if (calls > 1) throw new Error("getter called twice");
+        return "one.html";
+      },
+    });
+    Object.defineProperty(tpl, "label", {
+      get() {
+        return "One";
+      },
+    });
+    render(
+      <TemplateLoader templates={[tpl]} onLoad={() => {}} onClear={() => {}} />,
+    );
+    expect(calls).toBe(1);
+  });
 });

--- a/tests/extensions/indentation.edge.test.ts
+++ b/tests/extensions/indentation.edge.test.ts
@@ -19,4 +19,22 @@ describe("tiptapIndentation", () => {
     });
     expect(updateAttributes).toHaveBeenCalledWith("paragraph", { "data-indent": 0 });
   });
+
+  it("treats negative indent as zero", () => {
+    const updateAttributes = vi.fn();
+    indentCommand({
+      editor: { getAttributes: () => ({ "data-indent": -2 }) },
+      commands: { updateAttributes },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith("paragraph", { "data-indent": 1 });
+  });
+
+  it("floors fractional indent values", () => {
+    const updateAttributes = vi.fn();
+    indentCommand({
+      editor: { getAttributes: () => ({ "data-indent": 2.7 }) },
+      commands: { updateAttributes },
+    });
+    expect(updateAttributes).toHaveBeenCalledWith("paragraph", { "data-indent": 3 });
+  });
 });

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -111,6 +111,15 @@ describe("validateTemplate", () => {
     );
   });
 
+  it("rejects word-joiner characters", () => {
+    const wj = "\u2060";
+    assert.strictEqual(validateDocument({ content: wj }), false);
+    assert.strictEqual(
+      validateTemplate({ title: "t", body: wj }),
+      false,
+    );
+  });
+
   it("returns false when property getters throw", () => {
     const tpl: any = {};
     Object.defineProperty(tpl, "title", {

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -3,7 +3,7 @@
  * @param doc - Arbitrary document data to validate.
  * @returns `true` if the document has a `content` string field, `false` otherwise.
  */
-const ZWS_RE = /[\s\u200B\u200C\u200D\uFEFF]+/g;
+const ZWS_RE = /[\s\u200B-\u200D\u2060-\u206F\uFEFF]+/g;
 
 function isStringLike(v: unknown): v is string | String {
   return typeof v === "string" || v instanceof String;


### PR DESCRIPTION
## Summary
- avoid double-accessing template props in TemplateLoader
- clamp and normalize indent levels in tiptapIndentation
- treat additional zero-width characters as blank in validation helpers

## Testing
- `NODE_V8_COVERAGE=coverage npm test`
- `node scripts/coverage-summary.js coverage`

------
https://chatgpt.com/codex/tasks/task_e_68be14f5982c833289eeb07423e9f914