### PR TITLE
Add minimal lint/test GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Node CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-and-test:
+    name: Lint and unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run Vitest suite
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ This repository includes a `.nvmrc` file pinned to the recommended Node.js LTS
 version. Most `nvm` implementations will automatically pick up this version so
 contributors can simply run `nvm use`.
 
+## Continuous Integration
+
+GitHub Actions runs a single workflow, [`Node CI`](.github/workflows/ci.yml), on
+every push to `main` and on pull requests. The job installs dependencies once,
+then executes `npm run lint` for ESLint and `npm test` for the Vitest suite. The
+workflow intentionally omits the standalone TypeScript check for now because the
+codebase contains long-standing type errors that still need to be addressed. You
+can run `npm run typecheck` locally to see the current failures and tackle them
+incrementally.
+
 ```
 cat .nvmrc
 ```


### PR DESCRIPTION
## Summary
- add a Node CI workflow that runs npm lint and vitest on pushes to main and PRs
- document the reduced CI surface and note that type-checking remains a manual follow-up

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d703f713888332aec383ef62d494b3