### PR TITLE
fix: align React shims with editor stubs

### DIFF
--- a/components/TemplateLoader.tsx
+++ b/components/TemplateLoader.tsx
@@ -54,7 +54,7 @@ export default function TemplateLoader({
         return acc;
       }
 
-      const rec = tpl as Record<string, unknown>;
+      const rec = tpl as unknown as Record<string, unknown>;
       const rawFilename = rec.filename;
       const rawLabel = rec.label;
       if (typeof rawFilename !== "string" || typeof rawLabel !== "string") {

--- a/extensions/lint.ts
+++ b/extensions/lint.ts
@@ -53,7 +53,7 @@ export default Extension.create<{ rule: LintRule }>({
           },
         },
         props: {
-          decorations(state) {
+          decorations(this: any, state) {
             return this.getState(state);
           },
         },

--- a/stubs/ckeditor5-react.tsx
+++ b/stubs/ckeditor5-react.tsx
@@ -41,8 +41,8 @@ export const CKEditor: React.FC<CKEditorProps> = ({
 
   const exec = (command: string) => document.execCommand(command);
 
-  const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
-    onChange?.(e, editor);
+  const handleInput = () => {
+    onChange?.({}, editor);
   };
 
   return (

--- a/stubs/lexical-react.tsx
+++ b/stubs/lexical-react.tsx
@@ -17,7 +17,12 @@ interface Editor {
 
 const EditorContext = createContext<Editor | null>(null);
 
-export function LexicalComposer({ children }: { children: React.ReactNode }) {
+export function LexicalComposer({
+  children,
+}: {
+  children: React.ReactNode;
+  initialConfig?: Record<string, unknown>;
+}) {
   const rootRef = useRef<HTMLDivElement>(null);
   const historyRef = useRef<string[]>(['']);
   const indexRef = useRef(0);

--- a/stubs/toast-ui-react-editor.tsx
+++ b/stubs/toast-ui-react-editor.tsx
@@ -6,6 +6,7 @@ export interface EditorProps {
   previewStyle?: string;
   plugins?: any[];
   onChange?(): void;
+  usageStatistics?: boolean;
 }
 
 export interface EditorHandle {
@@ -101,8 +102,9 @@ const Editor = forwardRef<EditorHandle, EditorProps>(({ initialValue = '', onCha
       />
     </div>
   );
-});
+}) as unknown as React.FC<EditorProps & { ref?: React.Ref<EditorHandle> }>;
 
 export { Editor };
 export default Editor;
+export type Editor = EditorHandle;
 

--- a/tests/extensions/lint.test.ts
+++ b/tests/extensions/lint.test.ts
@@ -32,7 +32,7 @@ function createLintPlugin(rule: { match: (a: { tr: any }) => any[] }) {
       },
     },
     props: {
-      decorations(state) {
+      decorations(this: any, state) {
         return this.getState(state);
       },
     },

--- a/types/editor-modules.d.ts
+++ b/types/editor-modules.d.ts
@@ -1,9 +1,3 @@
-declare module "@toast-ui/react-editor" {
-    export class Editor {
-    getInstance(): any;
-  }
-  export const ToastEditor: React.FC<any>;
-}
 declare module "@toast-ui/editor/dist/toastui-editor.css";
 declare module "@editorjs/editorjs" {
   export default class EditorJS {
@@ -11,6 +5,10 @@ declare module "@editorjs/editorjs" {
     save(): Promise<any>;
     render(data: any): void;
     destroy(): void;
+    blocks: {
+      renderFromHTML(html: string): void;
+      [key: string]: any;
+    };
   }
 }
 declare module "@editorjs/header" {
@@ -42,6 +40,28 @@ declare module "@tiptap/react" {
   export function EditorContent(props: any): any;
   export function useEditor(props: any, deps?: any[]): any;
   export type Extension = any;
+}
+declare module "@tiptap/core" {
+  export class Editor {
+    constructor(options?: any);
+    chain(): ChainedCommands;
+    getHTML(): string;
+    getAttributes(name: string): Record<string, unknown>;
+  }
+  export interface ChainedCommands {
+    setTextSelection(pos: number): ChainedCommands;
+    indent(): ChainedCommands;
+    outdent(): ChainedCommands;
+    run(): void;
+  }
+  export type RawCommands = Record<string, any>;
+  export const Extension: {
+    create<T = any>(config: any): any;
+  };
+  export function mergeAttributes(...inputs: any[]): Record<string, any>;
+  export class Node {
+    static create(config: any): any;
+  }
 }
 declare module "@tiptap/starter-kit" {
   const StarterKit: any;

--- a/types/lucide-react.d.ts
+++ b/types/lucide-react.d.ts
@@ -12,4 +12,9 @@ declare module "lucide-react" {
   export const Strikethrough: any;
   export const Underline: any;
   export const Undo2: any;
+  export const Image: any;
+  export const Table: any;
+  export const Menu: any;
+  export const X: any;
+  export const Loader2: any;
 }

--- a/types/prosemirror.d.ts
+++ b/types/prosemirror.d.ts
@@ -1,6 +1,18 @@
 declare module "prosemirror-state" {
+  export class Plugin {
+    constructor(config: any);
+    getState(state: any): any;
+    props: {
+      decorations(this: { getState(state: any): any }, state: any): any;
+      [key: string]: any;
+    };
+    spec: any;
+  }
+  export class PluginKey {
+    constructor(name?: string);
+    get(state: any): any;
+  }
   export const TextSelection: any;
-  export const Plugin: any;
 }
 
 declare module "prosemirror-model" {

--- a/types/shims.d.ts
+++ b/types/shims.d.ts
@@ -12,6 +12,12 @@ declare module "react" {
   /** Minimal React type definitions for offline compilation */
   export type Dispatch<A> = (value: A) => void;
   export type SetStateAction<S> = S | ((prevState: S) => S);
+  export interface MutableRefObject<T> {
+    current: T;
+  }
+  export type RefObject<T> = MutableRefObject<T | null>;
+  export type RefCallback<T> = (instance: T | null) => void;
+  export type Ref<T> = RefObject<T> | RefCallback<T> | null;
   export function useState<S>(
     initialState: S | (() => S),
   ): [S, Dispatch<SetStateAction<S>>];
@@ -20,22 +26,69 @@ declare module "react" {
     Dispatch<SetStateAction<S | undefined>>,
   ];
   export const useEffect: any;
-  export function useRef<T>(initial?: T | null): { current: T | null };
+  export function useRef<T>(initialValue: T): MutableRefObject<T>;
+  export function useRef<T>(initialValue: T | null): MutableRefObject<
+    T | null
+  >;
+  export function useRef<T = undefined>(): MutableRefObject<T | undefined>;
   export function useMemo<T>(factory: () => T, deps: any[]): T;
   export function useCallback<T extends (...args: any[]) => any>(
     fn: T,
     deps: any[],
   ): T;
+  export interface Context<T> {
+    Provider: React.FC<{ value: T; children?: React.ReactNode }>;
+    Consumer: React.FC<{ children: (value: T) => React.ReactNode }>;
+    _currentValue: T;
+  }
+  export function createContext<T>(defaultValue: T): Context<T>;
+  export function useContext<T>(context: Context<T>): T;
+  export type ForwardRefRenderFunction<T, P = {}> = (
+    props: P,
+    ref: React.Ref<T>,
+  ) => any;
+  export function forwardRef<T, P = {}>(
+    render: ForwardRefRenderFunction<T, P>,
+  ): React.ForwardRefExoticComponent<P & React.RefAttributes<T>>;
+  export function useImperativeHandle<T, R extends T>(
+    ref: React.Ref<T> | undefined,
+    init: () => R,
+    deps?: any[],
+  ): void;
   const React: any;
   export default React;
   namespace React {
     export type Dispatch<A> = (value: A) => void;
     export type SetStateAction<S> = S | ((prevState: S) => S);
     export type FC<P = {}> = (props: P) => any;
+    export interface MutableRefObject<T> {
+      current: T;
+    }
+    export type RefObject<T> = MutableRefObject<T | null>;
+    export type RefCallback<T> = (instance: T | null) => void;
+    export type Ref<T> = RefObject<T> | RefCallback<T> | null;
     export interface ChangeEvent<T = Element> {
       target: T;
     }
+    export interface FormEvent<T = Element> {
+      target: T;
+      preventDefault(): void;
+    }
     export type ReactNode = any;
+    export interface HTMLAttributes<T> {
+      [key: string]: any;
+    }
+    export interface RefAttributes<T> {
+      ref?: Ref<T>;
+    }
+    export interface ForwardRefExoticComponent<P> {
+      (props: P): any;
+    }
+    export interface Context<T> {
+      Provider: FC<{ value: T; children?: ReactNode }>;
+      Consumer: FC<{ children: (value: T) => ReactNode }>;
+      _currentValue: T;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the custom React type shim with context APIs, ref helpers, and additional hooks required by the editor stubs
- update stub modules and ambient declarations so lexical, toast UI, and tiptap integrations expose the props and commands our pages use
- relax lint extension typing to allow `this` access and add minor casting adjustments to keep typechecking green

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d83ac93ddc8332b1f36f7be84ba168