### PR TITLE
fix(lexical): align LexicalComposer stub props

### DIFF
--- a/stubs/lexical-react.tsx
+++ b/stubs/lexical-react.tsx
@@ -17,15 +17,30 @@ interface Editor {
 
 const EditorContext = createContext<Editor | null>(null);
 
-export function LexicalComposer({
-  children,
-}: {
+interface LexicalComposerProps {
   children: React.ReactNode;
   initialConfig?: Record<string, unknown>;
-}) {
+  onError?: (error: Error) => void;
+}
+
+export function LexicalComposer({
+  children,
+  initialConfig,
+  onError,
+}: LexicalComposerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const historyRef = useRef<string[]>(['']);
   const indexRef = useRef(0);
+  const configRef = useRef<LexicalComposerProps['initialConfig']>(initialConfig);
+  const errorHandlerRef = useRef<LexicalComposerProps['onError']>(onError);
+
+  useEffect(() => {
+    configRef.current = initialConfig;
+  }, [initialConfig]);
+
+  useEffect(() => {
+    errorHandlerRef.current = onError;
+  }, [onError]);
 
   const editor: Editor = {
     rootRef,


### PR DESCRIPTION
## Summary
- allow the LexicalComposer stub to accept an initialConfig prop and optional onError handler
- store the provided configuration and error handler references so the stub mirrors the public API shape

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d840cf705c8332afeff0aab94469e1