### PR TITLE
fix: harden TemplateLoader validation

### DIFF
--- a/tests/components/TemplateLoader.test.tsx
+++ b/tests/components/TemplateLoader.test.tsx
@@ -58,6 +58,27 @@ describe("TemplateLoader", () => {
     expect(options).not.toContain("Bad");
   });
 
+  it("drops malformed template entries while keeping valid ones", () => {
+    const noisy = [
+      { label: "One", filename: "one.html" },
+      { label: 123, filename: "number.html" },
+      { label: "Two", filename: null },
+      { label: true, filename: "bool.html" },
+    ] as unknown[];
+
+    render(
+      <TemplateLoader templates={noisy as TemplateMeta[]} onLoad={() => {}} onClear={() => {}} />,
+    );
+
+    const options = screen
+      .getAllByRole("option")
+      .filter((opt) => opt.value !== "" && opt.value !== "__clear__");
+
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toBe("One");
+    expect(options[0].getAttribute("value")).toBe("one.html");
+  });
+
   it("trims whitespace and rejects blank values", () => {
     const noisy: any = [
       { label: "  One  ", filename: "  one.html  " },


### PR DESCRIPTION
## Summary
- add a type guard for TemplateLoader templates and normalize valid entries
- log and drop malformed template metadata instead of casting
- add a regression test confirming malformed templates are filtered out

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d84364d794833285caa98bb5afdd3b