### PR TITLE
fix: improve prosemirror lint typings

### DIFF
--- a/tests/extensions/lint.test.ts
+++ b/tests/extensions/lint.test.ts
@@ -52,7 +52,7 @@ describe("lint extension", () => {
       .spyOn(DecorationSet, "create")
       .mockReturnValue(DecorationSet.empty as any);
     const tr = { docChanged: true, doc: {} } as any;
-    expect(() => plugin.spec.state.apply(tr, DecorationSet.empty)).not.toThrow();
+    expect(() => plugin.spec.state!.apply(tr, DecorationSet.empty)).not.toThrow();
     expect(spyInline).toHaveBeenCalledTimes(1);
     expect(spyInline).toHaveBeenCalledWith(0, 1, expect.any(Object));
     spyInline.mockRestore();

--- a/types/prosemirror.d.ts
+++ b/types/prosemirror.d.ts
@@ -1,17 +1,52 @@
 declare module "prosemirror-state" {
-  export class Plugin {
-    constructor(config: any);
-    getState(state: any): any;
-    props: {
-      decorations(this: { getState(state: any): any }, state: any): any;
-      [key: string]: any;
-    };
-    spec: any;
+  export interface EditorState {
+    doc: unknown;
   }
-  export class PluginKey {
+
+  export interface Transaction {
+    docChanged: boolean;
+    doc: unknown;
+  }
+
+  export interface PluginStateField<State> {
+    init(config: { state: EditorState }, instance: EditorState): State;
+    apply(
+      tr: Transaction,
+      value: State,
+      oldState?: EditorState,
+      newState?: EditorState,
+    ): State;
+  }
+
+  export type DecorationsHandler<State> =
+    | ((this: Plugin<State>, state: EditorState) => import("prosemirror-view").DecorationSet | null | undefined)
+    | ((state: EditorState) => import("prosemirror-view").DecorationSet | null | undefined);
+
+  export interface PluginProps<State> {
+    decorations?: DecorationsHandler<State>;
+    [key: string]: any;
+  }
+
+  export interface PluginSpec<State = unknown> {
+    key?: PluginKey<State>;
+    state?: PluginStateField<State>;
+    props?: PluginProps<State>;
+    [key: string]: any;
+  }
+
+  export class Plugin<State = unknown> {
+    constructor(spec: PluginSpec<State>);
+    readonly spec: PluginSpec<State>;
+    readonly props?: PluginProps<State>;
+    getState(state: EditorState): State | undefined;
+  }
+
+  export class PluginKey<State = unknown> {
     constructor(name?: string);
-    get(state: any): any;
+    get(state: EditorState): Plugin<State> | undefined;
+    getState(state: EditorState): State | undefined;
   }
+
   export const TextSelection: any;
 }
 
@@ -20,5 +55,21 @@ declare module "prosemirror-model" {
     type: { name: string };
     attrs: any;
     text?: string;
+  }
+}
+
+declare module "prosemirror-view" {
+  export class Decoration {
+    static inline(
+      from: number,
+      to: number,
+      attrs?: Record<string, any>,
+      spec?: any,
+    ): Decoration;
+  }
+
+  export class DecorationSet {
+    static empty: DecorationSet;
+    static create(doc: unknown, decorations: Decoration[]): DecorationSet;
   }
 }


### PR DESCRIPTION
## Summary
- add minimal Plugin/PluginSpec typings that expose getState and decoration handlers
- stub the Decoration and DecorationSet APIs needed by the lint extension
- adjust the lint extension test to account for the optional plugin state field

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d84565687c8332a98787766f83a154