### PR TITLE
fix: align EditorJS typing with block utilities

### DIFF
--- a/stubs/editorjs.ts
+++ b/stubs/editorjs.ts
@@ -4,13 +4,21 @@ export default class EditorJS {
   public config: any;
   private data: { blocks: Block[] } = { blocks: [] };
   public blocks = {
-    insert: (type: string, data: any) => {
+    insert: async (type: string, data: any) => {
       this.data.blocks.push({ type, data });
       this.config?.onChange?.();
     },
-    renderFromHTML: (html: string) => {
+    render: async (data: { blocks: Block[] }) => {
+      this.data = data;
+      this.config?.onChange?.();
+    },
+    renderFromHTML: async (html: string) => {
       const text = html.replace(/<[^>]+>/g, "");
       this.data.blocks = [{ type: "paragraph", data: { text } }];
+      this.config?.onChange?.();
+    },
+    clear: async () => {
+      this.data.blocks = [];
       this.config?.onChange?.();
     },
   };
@@ -31,6 +39,10 @@ export default class EditorJS {
   }
   async save() {
     return this.data;
+  }
+  async render(data: { blocks: Block[] }) {
+    this.data = data;
+    this.config?.onChange?.();
   }
   destroy() {
     // no-op

--- a/types/editor-modules.d.ts
+++ b/types/editor-modules.d.ts
@@ -1,14 +1,19 @@
 declare module "@toast-ui/editor/dist/toastui-editor.css";
 declare module "@editorjs/editorjs" {
+  export interface EditorBlocks {
+    insert(type: string, data?: any, config?: any): Promise<void>;
+    render(data: any): Promise<void>;
+    renderFromHTML(html: string): Promise<void>;
+    clear(): Promise<void>;
+    [key: string]: any;
+  }
+
   export default class EditorJS {
     constructor(options?: any);
     save(): Promise<any>;
-    render(data: any): void;
+    render(data: any): Promise<void>;
     destroy(): void;
-    blocks: {
-      renderFromHTML(html: string): void;
-      [key: string]: any;
-    };
+    blocks: EditorBlocks;
   }
 }
 declare module "@editorjs/header" {


### PR DESCRIPTION
## Summary
- extend the `@editorjs/editorjs` declaration with a typed `blocks` helper that mirrors the local usage
- update the EditorJS stub to expose async block helpers and a render method that match the declaration

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d84ab709948332a0a3299662459b1b