### PR TITLE
chore: type indentation commands for tiptap

### DIFF
--- a/extensions/tiptapIndentation.ts
+++ b/extensions/tiptapIndentation.ts
@@ -2,18 +2,26 @@
  * TipTap extension adding indentation controls.
  */
 import { Extension, RawCommands } from "@tiptap/core";
-import { Node as PMNode } from "prosemirror-model";
 
-/**
- * Minimal indentation extension returning a blank command set.
- */
+type IndentationCommandProps = {
+  editor: {
+    getAttributes: (name: string) => Record<string, unknown>;
+  };
+  commands: {
+    updateAttributes: (
+      name: string,
+      attributes: Record<string, unknown>
+    ) => boolean;
+  };
+};
+
 /**
  * Adds simple indent/outdent commands by storing the level
  * in a `data-indent` attribute on paragraphs and list items.
  */
-export function getIndentLevel(editor: {
-  getAttributes: (name: string) => Record<string, unknown>;
-}): number {
+export function getIndentLevel(
+  editor: IndentationCommandProps["editor"]
+): number {
   const val = editor.getAttributes("paragraph")["data-indent"];
   const num = typeof val === "number" ? val : Number(val);
   if (!Number.isFinite(num) || num <= 0) return 0;
@@ -23,10 +31,7 @@ export function getIndentLevel(editor: {
 export function indentCommand({
   editor,
   commands,
-}: {
-  editor: any;
-  commands: any;
-}): any {
+}: IndentationCommandProps): boolean {
   const level = getIndentLevel(editor);
   return commands.updateAttributes("paragraph", {
     "data-indent": level + 1,
@@ -36,10 +41,7 @@ export function indentCommand({
 export function outdentCommand({
   editor,
   commands,
-}: {
-  editor: any;
-  commands: any;
-}): any {
+}: IndentationCommandProps): boolean {
   const level = getIndentLevel(editor);
   return commands.updateAttributes("paragraph", {
     "data-indent": Math.max(0, level - 1),

--- a/types/tiptap-indentation.d.ts
+++ b/types/tiptap-indentation.d.ts
@@ -1,0 +1,27 @@
+import type {
+  indentCommand,
+  outdentCommand,
+} from "../extensions/tiptapIndentation";
+
+type IndentReturn = ReturnType<typeof indentCommand>;
+type OutdentReturn = ReturnType<typeof outdentCommand>;
+
+declare module "@tiptap/core" {
+  type IndentationCommandReturn<ReturnType> = ReturnType extends ChainedCommands
+    ? ChainedCommands
+    : ReturnType extends boolean
+    ? IndentReturn & OutdentReturn
+    : ReturnType;
+
+  interface Commands<ReturnType = any> {
+    indentation: {
+      indent: () => IndentationCommandReturn<ReturnType>;
+      outdent: () => IndentationCommandReturn<ReturnType>;
+    };
+  }
+
+  interface ChainedCommands {
+    indent(): IndentationCommandReturn<ChainedCommands>;
+    outdent(): IndentationCommandReturn<ChainedCommands>;
+  }
+}


### PR DESCRIPTION
## Summary
- refine the tiptap indentation commands with explicit props typings
- add a module augmentation so indent/outdent are exposed on Commands and ChainedCommands using the extension return types

## Testing
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d84c0987708332a505d0efce0968a5